### PR TITLE
Fix not resolving Bioconductor dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,6 +30,7 @@ Imports: edgeR (>= 3.34.0), doParallel (>= 1.0.15),
         (>= 0.24)
 Suggests: knitr, rmarkdown
 VignetteBuilder: knitr
+biocViews:
 Depends: R (>= 4.1.0)
 NeedsCompilation: no
 Packaged: 2021-11-03 02:24:40 UTC; delivera.a


### PR DESCRIPTION
The `devtools::install_github()` command, as documented in your README[^1], won't resolve any of the Bioconductor dependencies and the installation for this package will fail with the following message:

```
Warning messages:
1: packages ‘dittoSeq’, ‘scMerge’, ‘celldex’, ‘SingleR’, ‘scuttle’, ‘scran’, ‘scater’, ‘BiocParallel’, ‘SingleCellExperiment’, ‘edgeR’ are not available for this version of R

Versions of these packages for your version of R might be available elsewhere,
see the ideas at
https://cran.r-project.org/doc/manuals/r-patched/R-admin.html#Installing-packages 
2: In i.p(...) :
  installation of package ‘/tmp/RtmpeSmmX8/file327c8d30e3b739/ruvIIInb_0.7.8.5.tar.gz’ had non-zero exit status
```

This change allows the resolution of these dependencies[^2]. I have tested this as working on R 4.2.0.

[^1]: https://github.com/limfuxing/ruvIIInb/blob/4aa88a75f8d275494125bef94dd650a5d4bc5b19/README.md#installation
[^2]: https://github.com/r-lib/remotes/blob/c2013c25d905d73ca4326f2c5829165fea55f2ea/R/utils.R#L46